### PR TITLE
Make mod/recent_posts.html template respect $config['dir']['res']

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -249,9 +249,9 @@ function loadConfig() {
 		if ($config['allow_roll'])
 			event_handler('post', 'diceRoller');
 
-		if (is_array($config['anonymous']))
-			$config['anonymous'] = $config['anonymous'][array_rand($config['anonymous'])];
-
+		if (in_array('webm', $config['allowed_ext_files']) ||
+        	    in_array('mp4',  $config['allowed_ext_files']))
+			event_handler('post', 'postHandler');
 	}
 	// Effectful config processing below:
 
@@ -287,10 +287,9 @@ function loadConfig() {
 	if ($config['cache']['enabled'])
 		require_once 'inc/cache.php';
 
-	if (in_array('webm', $config['allowed_ext_files'])) {
+	if (in_array('webm', $config['allowed_ext_files']) ||
+            in_array('mp4',  $config['allowed_ext_files']))
 		require_once 'inc/lib/webm/posthandler.php';
-		event_handler('post', 'postHandler');
-	}
 
 	event('load-config');
 
@@ -308,6 +307,9 @@ function loadConfig() {
 		Cache::set('config_'.$boardsuffix, $config);
 		Cache::set('events_'.$boardsuffix, $events);
 	}
+
+	if (is_array($config['anonymous']))
+		$config['anonymous'] = $config['anonymous'][array_rand($config['anonymous'])];
 	
 	if ($config['debug']) {
 		if (!isset($debug)) {


### PR DESCRIPTION
![Image](https://i.imgur.com/ZuUvIdb.png)

So these links in the mod panel's recent posts page don't keep linking to /board/res/ despite your change to $config['dir']['res']